### PR TITLE
feat: Update website color palette to Republican purple

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,26 +14,26 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-color-primary: #5A007B;
+  --ifm-color-primary-dark: #4F006A;
+  --ifm-color-primary-darker: #45005E;
+  --ifm-color-primary-darkest: #3A0050;
+  --ifm-color-primary-light: #6B1A8C;
+  --ifm-color-primary-lighter: #7C339D;
+  --ifm-color-primary-lightest: #8D4DBE;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-color-primary: #9370DB;
+  --ifm-color-primary-dark: #825ACB;
+  --ifm-color-primary-darker: #7A4FCC;
+  --ifm-color-primary-darkest: #693AC5;
+  --ifm-color-primary-light: #A484E0;
+  --ifm-color-primary-lighter: #B598E5;
+  --ifm-color-primary-lightest: #C6ACEB;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
This commit updates the website's color scheme to use shades of purple inspired by the "morado comunero" of the Republican Spanish flag.

The primary color variables in `src/css/custom.css` have been updated for both light and dark themes to reflect this new palette.